### PR TITLE
Fix typos on the Japanese python advanced page.

### DIFF
--- a/ja/source/guide/2.0_python_advanced.rst
+++ b/ja/source/guide/2.0_python_advanced.rst
@@ -1146,7 +1146,7 @@ int型のリストを引数として受け取り、bool型を返す関数でな�
    n = 5
    coef = 2.0
    Pauli_string = "X 0 X 1 Y 2 Z 4"
-   pauli = Pauli(Pauli_string,coef)
+   pauli = PauliOperator(Pauli_string,coef)
 
    # 期待値の計算 <a|H|a>
    state = QuantumState(n)
@@ -1181,7 +1181,7 @@ int型のリストを引数として受け取り、bool型を返す関数でな�
    # pauli演算子を追加できる
    coef = 2.0+0.5j
    Pauli_string = "X 0 X 1 Y 2 Z 4"
-   pauli = Pauli(Pauli_string,coef)
+   pauli = PauliOperator(Pauli_string,coef)
    operator.add_operator(pauli)
    # 直接係数と文字列から追加することもできる
    operator.add_operator(0.5j, "Y 1 Z 4")


### PR DESCRIPTION
This PR fixes issue #26.

### Changes
`Pauli -> PauliOperator` in パウリ演算子の期待値 and 一般の線形演算子.