### PR TITLE
Fix API document

### DIFF
--- a/en/source/conf.py
+++ b/en/source/conf.py
@@ -49,15 +49,21 @@ exhale_args = {
     # Suggested optional arguments
     "createTreeView":        True,
     # TIP: if using the sphinx-bootstrap-theme, you need
-    "treeViewIsBootstrap": True,
-     "exhaleExecutesDoxygen": True,
-     "exhaleDoxygenStdin": \
-        "INPUT = ../../qulacs-src \n \
+    # "treeViewIsBootstrap": True,
+    "exhaleExecutesDoxygen": True,
+    "exhaleDoxygenStdin": \
+        "INPUT = ../../qulacs/src/cppsim ../../qulacs/src/vqcsim \n \
+        FILE_PATTERNS          = *.hpp \n \
+        WARN_IF_UNDOCUMENTED   = NO \n \
+        ENABLE_PREPROCESSING   = YES \n \
+        MACRO_EXPANSION        = YES \n \
+        PREDEFINED             += __attribute__(x)= \n \
+        PREDEFINED             += DllExport= \n \
         OUTPUT_LANGUAGE = English \n \
         GENERATE_LEGEND        = YES \n \
         GRAPHICAL_HIERARCHY    = YES \n \
-        CLASS_GRAPH            = YES \n\
-        HIDE_UNDOC_RELATIONS   = YES\n\
+        CLASS_GRAPH            = YES \n \
+        HIDE_UNDOC_RELATIONS   = YES\n \
         CLASS_DIAGRAMS         = YES\n"
 }
 

--- a/ja/source/conf.py
+++ b/ja/source/conf.py
@@ -50,15 +50,22 @@ exhale_args = {
     # Suggested optional arguments
     "createTreeView":        True,
     # TIP: if using the sphinx-bootstrap-theme, you need
-    "treeViewIsBootstrap": True,
-     "exhaleExecutesDoxygen": True,
-     "exhaleDoxygenStdin": \
-        "INPUT = ../../qulacs-src \n \
+    # "treeViewIsBootstrap": True,
+    "exhaleExecutesDoxygen": True,
+    "exhaleDoxygenStdin": \
+        "INPUT = ../../qulacs/src/cppsim ../../qulacs/src/vqcsim \n \
         OUTPUT_LANGUAGE = Japanese-en \n \
+        FILE_PATTERNS          = *.hpp \n \
+        WARN_IF_UNDOCUMENTED   = NO \n \
+        ENABLE_PREPROCESSING   = YES \n \
+        MACRO_EXPANSION        = YES \n \
+        PREDEFINED             += __attribute__(x)= \n \
+        PREDEFINED             += DllExport= \n \
+        OUTPUT_LANGUAGE = English \n \
         GENERATE_LEGEND        = YES \n \
         GRAPHICAL_HIERARCHY    = YES \n \
-        CLASS_GRAPH            = YES \n\
-        HIDE_UNDOC_RELATIONS   = YES\n\
+        CLASS_GRAPH            = YES \n \
+        HIDE_UNDOC_RELATIONS   = YES\n \
         CLASS_DIAGRAMS         = YES\n"
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 
 recommonmark == 0.6.*
-sphinx == 2.2.*
-breathe == 4.14.*
-exhale == 0.2.*
-nbsphinx == 0.5.*
+sphinx == 4.5.0
+sphinx-rtd-theme == 1.0.*
+breathe == 4.33.*
+exhale == 0.3.*
+nbsphinx == 0.8.*
 sphinx-copybutton
 ipykernel
 cmake


### PR DESCRIPTION
Fix some problems in API document.

- Document URLs (private preview)
  - C++ API Reference http://docs.qulacs.org/en/fix_doc/api/cpp_library_root.html
  - Python API Reference http://docs.qulacs.org/en/fix_doc/pyRef/modules.html

- Update Sphinx-related libraries
- Fix a problem that some classes (e.g. QuantumCircuit) did not appear on the reference
- Use header files from the submodule `qulacs/` instead of the copied version `qulacs-src/`
  - Note that updates made in #13 are not reflected, so this version is not ready to be made public yet
- Include `vqcsim` as well as `cppsim`