### PR TITLE
fix-typo about PauliOperator

### DIFF
--- a/ja/source/guide/2.0_python_advanced.rst
+++ b/ja/source/guide/2.0_python_advanced.rst
@@ -1146,7 +1146,7 @@ int型のリストを引数として受け取り、bool型を返す関数でな�
    n = 5
    coef = 2.0
    Pauli_string = "X 0 X 1 Y 2 Z 4"
-   pauli = Pauli(Pauli_string,coef)
+   pauli = PauliOperator(Pauli_string,coef)
 
    # 期待値の計算 <a|H|a>
    state = QuantumState(n)


### PR DESCRIPTION
fix typo about PauliOperator.
before: Pauli
after: PauliOperator