### PR TITLE
Fix `max_block_size` in Python tutorial

### DIFF
--- a/en/source/intro/4.1_python_tutorial.ipynb
+++ b/en/source/intro/4.1_python_tutorial.ipynb
@@ -1012,7 +1012,7 @@
     "# Optimization\n",
     "opt = QuantumCircuitOptimizer()\n",
     "# Maximum quantum gate size allowed to be created\n",
-    "max_block_size = 1\n",
+    "max_block_size = 3\n",
     "opt.optimize(circuit, max_block_size)\n",
     "# Calculate depth (depth=1へ)\n",
     "print(circuit.calculate_depth())"

--- a/ja/source/guide/2.0_python_advanced.rst
+++ b/ja/source/guide/2.0_python_advanced.rst
@@ -1335,7 +1335,7 @@ create_observable_from_openfermion_text create_split_observable
    # 最適化
    opt = QuantumCircuitOptimizer()
    # 作成を許す最大の量子ゲートのサイズ
-   max_block_size = 1
+   max_block_size = 3
    opt.optimize(circuit, max_block_size)
 
    # depthを計算(depth=1へ)


### PR DESCRIPTION
- Close #29

## 概要

ドキュメント内の文章では

> 下記のコードではoptimize関数を用いて、量子回路の量子ゲートをターゲットとなる量子ビットが3つになるまで貪欲法で合成を繰り返します。

となっていましたが、Pythonコードでは `max_block_size = 1`となっており、文章と一致していませんでした。
これをこのPRで修正します。

## 他に

- コマンドの実行結果も記載されていますが、実行結果に影響はありませんでした。
- C++向けチュートリアルでは`max_block_size = 3`と、正しいコードが記載されていました。