### PR TITLE
Tutorial PauliOperator

### DIFF
--- a/ja/source/guide/2.0_python_advanced.rst
+++ b/ja/source/guide/2.0_python_advanced.rst
@@ -1130,9 +1130,19 @@ int型のリストを引数として受け取り、bool型を返す関数でな�
    full_str = str(coef) + " " + " ".join(terms_str)
    print(full_str)
 
+   # pauliの係数を変更・取得
+   pauli.change_coef(0.5)
+   coef = pauli.get_coef()
+
+   # pauliの文字列表現を取得
+   pauli_strings = pauli.get_pauli_string()
+
+   print(coef, pauli_strings)
+
 ::
 
    (0.1+0j) X0 Y1 Z3 Y3
+   (0.5+0j) X 0 Y 1 Z 3 Y 3
 
 パウリ演算子の期待値
 ^^^^^^^^^^^^^^^^^^^^

--- a/ja/source/guide/2.0_python_advanced.rst
+++ b/ja/source/guide/2.0_python_advanced.rst
@@ -1126,7 +1126,7 @@ int型のリストを引数として受け取り、bool型を返す関数でな�
 
    s = ["I","X","Y","Z"]
    pauli_str = [s[i] for i in pauli_id_list]
-   terms_str = [item[0]+str(item[1]) for item in zip(pauli_str,index_list)]
+   terms_str = [item[0] + " " + str(item[1]) for item in zip(pauli_str,index_list)]
    full_str = str(coef) + " " + " ".join(terms_str)
    print(full_str)
 
@@ -1141,7 +1141,7 @@ int型のリストを引数として受け取り、bool型を返す関数でな�
 
 ::
 
-   (0.1+0j) X0 Y1 Z3 Y3
+   (0.1+0j) X 0 Y 1 Z 3 Y 3
    (0.5+0j) X 0 Y 1 Z 3 Y 3
 
 パウリ演算子の期待値


### PR DESCRIPTION
closed #34 

- change_coef()
- get_pauli_string()
の2つのメソッドをチュートリアルに書き加えました。

pauli_stringsという変数名にしたのは、PauliOperatorのコンストラクタの第一引数名がstringsだったので、それに合わせました。
printを離れた個所に2か所置くのは少しわかりにくい気はしたのですが、ほかの書き方が思いつ生きませんでした。