### PR TITLE
QuantumState tutorial

### DIFF
--- a/ja/source/guide/2.0_python_advanced.rst
+++ b/ja/source/guide/2.0_python_advanced.rst
@@ -40,6 +40,7 @@ complex128の精度で :math:`2^n`
 
 また、get_vectorおよびload関数で量子状態とnumpy
 arrayの相互変換が可能です。ノルムが保存しているかなどは原則チェックされません。
+get_vectorはすべての要素を配列で返しますが、get_amplitudeを用いると単一の要素を高速に取得できます。
 
 .. code:: python
 
@@ -50,11 +51,13 @@ arrayの相互変換が可能です。ノルムが保存しているかなどは
    print(vec)
    state.load([0,1,2,3])
    print(state.get_vector())
+   print(state.get_amplitude(2))
 
 ::
 
    [1.+0.j 0.+0.j 0.+0.j 0.+0.j]
    [0.+0.j 1.+0.j 2.+0.j 3.+0.j]
+   (2+0j)
 
 量子状態間のコピー
 ~~~~~~~~~~~~~~~~~~
@@ -146,6 +149,11 @@ arrayの相互変換が可能です。ノルムが保存しているかなどは
    samples = state.sampling(10)
    print("sampling", samples)
 
+   # 第2引数にseedを与えられる。
+   # 同じseedを指定すると常に同じサンプリング結果が返される。
+   samples_with_seed = state.sampling(10, 314)
+   print("sampling (with seed)", samples_with_seed)
+
    # 状態ベクトルがCPU/GPUのどちらにあるかを文字列で取得する
    dev_type = state.get_device_name()
    print("device", dev_type)
@@ -153,11 +161,12 @@ arrayの相互変換が可能です。ノルムが保存しているかなどは
 ::
 
    qubit_count 5
-   zero_prob_1 0.5151171741097239
-   marginal_prob 0.40401228349316776
-   entropy 3.0788233113265715
+   zero_prob_1 0.46010755964245975
+   marginal_prob 0.20030608663813237
+   entropy 3.108273642412474
    sqaured_norm 1.0
-   sampling [23, 9, 8, 4, 25, 7, 7, 24, 20, 27]
+   sampling [6, 22, 18, 7, 9, 6, 28, 28, 12, 17]
+   sampling (with seed) [23, 18, 28, 14, 17, 30, 9, 17, 16, 10]
    device cpu
 
 量子状態の変形
@@ -188,6 +197,15 @@ arrayの相互変換が可能です。ノルムが保存しているかなどは
    state.multiply_coef(coef)
    print("mul_coef", state.get_vector())
 
+   # 量子状態と、インデックスによって定められる複素数の積
+   # |00>方向にcoef_func(0),|01>方向にcoef_func(1),...を掛けます。
+   # 操作後のノルムは一般に1ではありません。
+   def coef_func(i: int) -> complex:
+       assert 0 <= i < 2**2
+       return 1j**i
+   state.multiply_elementwise_function(coef_func)
+   print("mul_elementwise_func", state.get_vector())
+
    # 量子状態の正規化
    # 引数として現在のsquared normを与える必要があります。
    squared_norm = state.get_squared_norm()
@@ -202,9 +220,10 @@ arrayの相互変換が可能です。ノルムが保存しているかなどは
    buffer [0.+0.j 0.+0.j 1.+0.j 0.+0.j]
    added [1.+0.j 0.+0.j 1.+0.j 0.+0.j]
    mul_coef [0.5+0.1j 0. +0.j  0.5+0.1j 0. +0.j ]
+   mul_elementwise_func [ 0.5+0.1j  0. +0.j  -0.5-0.1j  0. -0.j ]
    sq_norm 0.52
-   normalized [0.69337525+0.13867505j 0.        +0.j         0.69337525+0.13867505j
-    0.        +0.j        ]
+   normalized [ 0.69337525+0.13867505j  0.        +0.j         -0.69337525-0.13867505j
+     0.        -0.j        ]
    sq_norm 0.9999999999999998
 
 古典レジスタの操作

--- a/ja/source/intro/4.1_python_tutorial.md
+++ b/ja/source/intro/4.1_python_tutorial.md
@@ -157,6 +157,83 @@ print(value)
 (0.1265907720817918+0.10220657039660046j)
 ```
 
+### 量子状態のコピー
+QuantumState等のオブジェクトは、<code>=</code>で代入するとシャローコピーとなるため、<code>state1</code>を変更した場合<code>state2</code>も変更されてしまいます。
+```python
+from qulacs import QuantumState
+
+n = 2
+state1 = QuantumState(n)
+state1.set_zero_state()
+
+state2 = state1 # using "="
+print("===before change===")
+print(state2)
+
+state1.set_computational_basis(2)
+print("===after change===")
+print(state2)
+```
+```
+===before change===
+ *** Quantum State ***
+ * Qubit Count : 2
+ * Dimension   : 4
+ * State vector : 
+(1,0)
+(0,0)
+(0,0)
+(0,0)
+
+===after change===
+ *** Quantum State ***
+ * Qubit Count : 2
+ * Dimension   : 4
+ * State vector : 
+(0,0)
+(0,0)
+(1,0)
+(0,0)
+```
+
+`copy()`を使うとオブジェクトをディープコピーできるため、コピー元を変更してもコピー先には影響がなくなります。
+```python
+from qulacs import QuantumState
+
+n = 2
+state1 = QuantumState(n)
+state1.set_zero_state()
+
+state2 = state1.copy() # using "copy()"
+print("===before change===")
+print(state2)
+
+state1.set_computational_basis(2)
+print("===after change===")
+print(state2)
+```
+```
+===before change===
+ *** Quantum State ***
+ * Qubit Count : 2
+ * Dimension   : 4
+ * State vector : 
+(1,0)
+(0,0)
+(0,0)
+(0,0)
+
+===after change===
+ *** Quantum State ***
+ * Qubit Count : 2
+ * Dimension   : 4
+ * State vector : 
+(1,0)
+(0,0)
+(0,0)
+(0,0)
+```
+
 ## 量子ゲート
 
 ### 量子ゲートの生成

--- a/ja/source/intro/4.1_python_tutorial.md
+++ b/ja/source/intro/4.1_python_tutorial.md
@@ -158,7 +158,7 @@ print(value)
 ```
 
 ### 量子状態のコピー
-QuantumState等のオブジェクトは、<code>=</code>で代入するとシャローコピーとなるため、<code>state1</code>を変更した場合<code>state2</code>も変更されてしまいます。
+QuantumState等のオブジェクトは、<code>=</code>で代入すると浅いコピー(shallow copy)となるため、<code>state1</code>を変更した場合<code>state2</code>も変更されてしまいます。
 ```python
 from qulacs import QuantumState
 
@@ -196,7 +196,7 @@ print(state2)
 (0,0)
 ```
 
-`copy()`を使うとオブジェクトをディープコピーできるため、コピー元を変更してもコピー先には影響がなくなります。
+`copy()`を代わりに使うことで深いコピー(deep copy)となり、コピー元を変更してもコピー先には影響がなくなります。
 ```python
 from qulacs import QuantumState
 


### PR DESCRIPTION
指示：
```
o0 copy
o0 multiply_elementwise_function
o0 sampling(count, seed)
+0 get_amplitude
o0 StateVector
```
copyはAdvancedに言及はありましたが使用例はなかったのでTutorialのほうでわかりやすくやりました
StateVectorはコンストラクタということにはなっていないものの同じ引数列でQuantumStateのオブジェクトを作っていて本当にただの別名になっているだけなので書きませんでした
StateVector()をつかって初期化している人もいるかもしれないのでわざわざ削除はしなくてもいいと思いますが、あえて使わせる意味もないです…