### PR TITLE
add scipy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ sphinx-copybutton
 ipykernel
 cmake
 qulacs
+scipy


### PR DESCRIPTION
現在、依存関係の調整がうまくできておらずqulacsのインストール時に、scipyがインストールされない。
scipyがないと実行時にエラーになるので入れておく。