### PR TITLE
Fix qulacs version to 0.3.1.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ nbsphinx == 0.8.*
 sphinx-copybutton
 ipykernel
 cmake
-qulacs
+qulacs == 0.3.1
 scipy


### PR DESCRIPTION
## 概要

Python APIドキュメントが表示されない問題の対策として、Qulacsのバージョンを0.3.1に固定しました。