### PR TITLE
Add notice of repository integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# qulacs-rtd
+
+> **Note**
+> `qulacs-rtd` has been integrated into [qulacs](https://github.com/qulacs/qulacs/tree/main/doc) repository and is under development and maintenance.
+> If you find a problem with the [documentation page](http://docs.qulacs.org/), please contact [Issues](https://github.com/qulacs/qulacs/issues) or submit [Pull Requests](https://github.com/qulacs/qulacs/pulls) in the qulacs repository.
+
+Qulacs documentation for readthedocs. Configured to support automatically generate C++/Python API, and internationalization.


### PR DESCRIPTION
## 概要

qulacs-rtdはqulacsへ統合され、ドキュメントの保守や開発はqulacsで行うことになった旨をREADMEに追記しました。
このPRをmerge後、qulacs-rtdはPublic Archiveとする方針を考えています。

